### PR TITLE
ubuntu-checkpath: add monotonic check

### DIFF
--- a/ubuntu-checkpatch
+++ b/ubuntu-checkpatch
@@ -506,6 +506,46 @@ class CheckSeriesBugLink(Check):
 
         return 0
 
+class CheckSeriesMonotonicNumbers(Check):
+    """Check patch numbering is monotonic increase
+    """
+    RE_DIGIT_START = re.compile(r"^(\d+)[/_-]")
+
+    def run(self):
+        self.name = "monotonic_increase"
+        rc = 0
+
+        file_names = [os.path.basename(p.file) for p in self.series.patches]
+
+        # Catch inconsistent patch prefixes that cause out-of-order apply
+        common = os.path.commonprefix(file_names)
+        patch_nums = []
+        for file_name in file_names:
+            file_name = file_name[len(common):]
+
+            m = re.match(self.RE_DIGIT_START, file_name)
+            if not m or not m.group(1):
+                rc = 1
+                self.result(FAIL, "patch prefixes differ and will apply out of order")
+                break
+
+            number = m.group(1)
+            patch_nums.append(int(number))
+
+        # Check for monotonic increase
+        for i in range(1, len(patch_nums)):
+            a = patch_nums[i-1]
+            b = patch_nums[i]
+            if b - a != 1:
+                self.result(FAIL, "missing patch #{}".format(i))
+                rc = 1
+                break
+
+        if rc == 0:
+            from_to = "{}->{}".format(min(patch_nums), max(patch_nums))
+            self.result(PASS, "consistent patch ordering: " + from_to)
+
+        return rc
 
 class Patch():
     """ Patch class
@@ -783,13 +823,13 @@ class PatchSeries():
         checks = [
             CheckSeriesSOB(self),
             CheckSeriesBugLink(self),
+            CheckSeriesMonotonicNumbers(self)
         ]
 
         for i, check in enumerate(checks):
             rc += check.run()
             check.log(i + 1)
 
-        # TODO: check monotonic increase of patch number
         # TODO: check series/source target tags consistency
         return rc
 


### PR DESCRIPTION
Add a check for checking the monotonic increase of patch numbers. This check only apply to series. The check will detect a malformed prefix which indirectly breaks git apply in the same way as bad ordering. The use of /, -, and _ are supported PATCH N/M separators. Samples shown[1]

Signed-off-by: Cory Todd <cory.todd@canonical.com>

[1]
```
Good:
Check #3    monotonic_increase   [pass]  consistent patch ordering: 0->36

Missing:
Check #3    monotonic_increase   [fail]  missing patch #10

Bad Prefix:
Check #3    monotonic_increase   [fail]  patch prefixes differ and will apply out of order
```
