### PR TITLE
ubuntu-checkpatch: fix TypeError in CheckSeriesType

### DIFF
--- a/ubuntu-checkpatch
+++ b/ubuntu-checkpatch
@@ -439,7 +439,7 @@ class CheckSeriesType(Check):
         stype = self.series.patches[0].type
 
         if stype not in ("PATCH", "PULL"):
-            self.result(FAIL, "invalid series type: " + stype)
+            self.result(FAIL, "invalid series type: {}".format(stype))
             return 1
 
         if stype == "PULL" and len(self.series.patches) > 1:


### PR DESCRIPTION
Use .format instead of string append since stype could be None.

Signed-off-by: Cory Todd <cory.todd@canonical.com>