### PR TITLE
ubuntu-checkpatch: add cve format check

### DIFF
--- a/ubuntu-checkpatch
+++ b/ubuntu-checkpatch
@@ -21,6 +21,8 @@ RE_TAG_TYPE = re.compile(r"^(PATCH|PULL)\s*(v\d+)?\s*(\d+/\d+)?$")
 RE_TAG_TARGET = re.compile(r"^[a-zA-Z0-9-./:]+$")
 RE_TAG_FROM_COMMIT = re.compile(r"^\((cherry picked|backported) from commit ([0-9a-f]{40})\s*(.*)*\)$")
 
+RE_CVE = re.compile(r"CVE-[0-9]{4}-[0-9]{4,}")
+
 CACHE_DIR = "~/.cache/ubuntu-checkpatch"
 
 # Check results
@@ -298,15 +300,17 @@ class CheckBugLinkCVE(Check):
     def run(self):
         self.name = "buglink_cve"
 
+        rc = 0
         if not self.patch.buglinks and not self.patch.cves:
             self.result(FAIL, "missing BugLink/CVE tag")
             return 1
 
         for cve in self.patch.cves:
-            # TODO: Check CVE tag format
-            self.result(PASS, "valid CVE tag: " + cve)
-
-        rc = 0
+            if not re.match(RE_CVE, cve):
+                self.result(FAIL, "invalid CVE tag: " + cve)
+                rc += 1
+            else:
+                self.result(PASS, "valid CVE tag: " + cve)
 
         for link in self.patch.buglinks:
             if len(link) > 1:


### PR DESCRIPTION
Add check for validating a CVE number. The sequence number is now[1] variable in length with a minimum digit count of four.

[1] https://cve.mitre.org/cve/identifiers/syntaxchange.html

Signed-off-by: Cory Todd <cory.todd@canonical.com>