### PR TITLE
ubuntu-checkpatch: fix provenance regex

### DIFF
--- a/ubuntu-checkpatch
+++ b/ubuntu-checkpatch
@@ -19,7 +19,7 @@ from launchpadlib.launchpad import Launchpad
 
 RE_TAG_TYPE = re.compile(r"^(PATCH|PULL)\s*(v\d+)?\s*(\d+/\d+)?$")
 RE_TAG_TARGET = re.compile(r"^[a-zA-Z0-9-./:]+$")
-RE_TAG_FROM_COMMIT = re.compile(r"^\((cherry picked|backported) from commit ([0-9a-f]{40})\s*(.*)*\)$")
+RE_TAG_FROM_COMMIT = re.compile(r"^\((cherry picked|backported) from commit ([0-9a-f]{40})\s*(.*)\)$")
 
 CACHE_DIR = "~/.cache/ubuntu-checkpatch"
 


### PR DESCRIPTION
Repetition cannot be used on groups. The repitition inside the group is sufficient for what we need. Tested with no provenance, a string like linux-next, and a full URL.

Signed-off-by: Cory Todd <cory.todd@canonical.com>