### PR TITLE
ubuntu-checkpatch: add upstream proveance check

### DIFF
--- a/ubuntu-checkpatch
+++ b/ubuntu-checkpatch
@@ -368,10 +368,10 @@ class CheckCherrypickBackport(Check):
         if commit and self.patch.provenance in ("", "linux-next", "linux-stable"):
             linux_base = "https://git.kernel.org/pub/scm/linux/kernel/git"
             upstream = {
-                "": f"{linux_base}/torvalds/linux.git/commit/?id={commit}",
-                "linux-next": f"{linux_base}/stable/linux.git/commit/?id={commit}",
-                "linux-stable": f"{linux_base}/next/linux-next.git/commit/?id={commit}",
-            }[self.patch.provenance]
+                "": "{linux_base}/torvalds/linux.git/commit/?id={commit}",
+                "linux-next": "{linux_base}/stable/linux.git/commit/?id={commit}",
+                "linux-stable": "{linux_base}/next/linux-next.git/commit/?id={commit}",
+            }[self.patch.provenance].format(linux_base=linux_base, commit=commit)
             r = requests.get(upstream)
             if r.status_code == 200:
                 self.result(PASS, "declared provenance contains referenced commit")
@@ -379,7 +379,8 @@ class CheckCherrypickBackport(Check):
                 self.result(FAIL, "declared provenance does not contain referenced commit")
                 rc = 1
             else:
-                self.result(WARN, f"unable to check upstream for commit: {upstream} returned HTTP_STATUS={r.status_code}")
+                self.result(WARN, "unable to check upstream for commit: " + 
+                                  "{} returned HTTP_STATUS={}".format(upstream, r.status_code))
                 rc = 1
 
         return rc

--- a/ubuntu-checkpatch
+++ b/ubuntu-checkpatch
@@ -379,7 +379,7 @@ class CheckCherrypickBackport(Check):
                 self.result(FAIL, "declared provenance does not contain referenced commit")
                 rc = 1
             else:
-                self.result(WARN, "unable to check upstream for commit: " + 
+                self.result(FAIL, "unable to check upstream for commit: " + 
                                   "{} returned HTTP_STATUS={}".format(upstream, r.status_code))
                 rc = 1
 

--- a/ubuntu-checkpatch
+++ b/ubuntu-checkpatch
@@ -8,6 +8,7 @@ import email
 import logging
 import os
 import re
+import requests
 import sys
 import time
 import yaml
@@ -354,6 +355,8 @@ class CheckCherrypickBackport(Check):
             self.result(FAIL, "cherrypick and backport tags present")
             return 1
 
+        rc = 0
+        commit = None
         if self.patch.cherrypick:
             commit = self.patch.cherrypick
             self.result(PASS, "valid cherrypick from commit: " + commit)
@@ -362,8 +365,24 @@ class CheckCherrypickBackport(Check):
             commit = self.patch.backport
             self.result(PASS, "valid backport from commit: " + commit)
 
-        # TODO: Check provenance and upstream commit existence
-        return 0
+        if commit and self.patch.provenance in ("", "linux-next", "linux-stable"):
+            linux_base = "https://git.kernel.org/pub/scm/linux/kernel/git"
+            upstream = {
+                "": f"{linux_base}/torvalds/linux.git/commit/?id={commit}",
+                "linux-next": f"{linux_base}/stable/linux.git/commit/?id={commit}",
+                "linux-stable": f"{linux_base}/next/linux-next.git/commit/?id={commit}",
+            }[self.patch.provenance]
+            r = requests.get(upstream)
+            if r.status_code == 200:
+                self.result(PASS, "declared provenance contains referenced commit")
+            elif r.status_code == 404:
+                self.result(FAIL, "declared provenance does not contain referenced commit")
+                rc = 1
+            else:
+                self.result(WARN, f"unable to check upstream for commit: {upstream} returned HTTP_STATUS={r.status_code}")
+                rc = 1
+
+        return rc
 
 
 class CheckSignerComment(Check):


### PR DESCRIPTION
If the declared provenance is one of the common upstreams, check that the referenced commit exists using an HTTP request.

I know you said to stick to the stdlib but requests seems like a fair requirement here.